### PR TITLE
fix: Disables the snapshotter to reduce error message rate

### DIFF
--- a/modules/eks/main.tf
+++ b/modules/eks/main.tf
@@ -70,6 +70,13 @@ module "eks" {
     aws-ebs-csi-driver = {
       service_account_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.deployment_name}-ebs-csi-controller"
       most_recent              = true
+      configuration_values     = jsonencode({
+        "sidecars": {
+          "snapshotter": {
+            "forceEnable": false
+          }
+        }
+      })
     }
   }
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- fix: A bug fix

## Description

The CSI driver contains a number of pods that do different things. One of them is a snapshotter. The correct version of that CRD is not deployed by default (v1beta1 -> v1), so the snapshotter is erroring on 

```E0221 12:16:28.823037       1 reflector.go:147] k8s.io/client-go@v0.28.0/tools/cache/reflector.go:229: 
Failed to watch *v1.VolumeSnapshotClass: failed to list *v1.VolumeSnapshotClass: 
the server could not find the requested resource (get volumesnapshotclasses.snapshot.storage.k8s.io)```

Disabling it makes those error messages go away on our observability tool, where we use pattern detection on error stages to alert us if there are changes to these error patterns.
