### PR TITLE
fix: Disk size setting on root volume

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -89,6 +89,19 @@ module "eks" {
             "k8s.io/cluster-autoscaler/${var.deployment_name}"   = "owned"
             "k8s.io/cluster-autoscaler/node-template/label/role" = "${var.deployment_name}"
         }
+        block_device_mappings = {
+          xvda = {
+            device_name = "/dev/xvda"
+            ebs = {
+              volume_size           = var.default_node_disk_size
+              volume_type           = "gp3"
+              iops                  = 3000
+              throughput            = 125
+              encrypted             = true
+              delete_on_termination = true
+            }
+          }
+        }
       })
   }
   create_aws_auth_configmap           = var.create_aws_auth_configmap


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- fix: A bug fix

## Description

The disk_size setting is not really applied. Now it merges a block_device_mapping which does apply this properly.