### PR TITLE
fix: Allow dns_name for vpces to be optional

### DIFF
--- a/modules/load_balancer/variables.tf
+++ b/modules/load_balancer/variables.tf
@@ -99,7 +99,7 @@ variable "lb_vpces_details" {
   default = null
   type = object({
     allowed_principals  = list(string)
-    private_dns_name    = string
+    private_dns_name    = optional(string)
     acceptance_required = bool
 
     supported_ip_address_types = list(string)

--- a/variables.tf
+++ b/variables.tf
@@ -379,7 +379,7 @@ variable "lb_vpces_details" {
   default = null
   type = object({
     allowed_principals  = list(string)
-    private_dns_name    = string
+    private_dns_name    = optional(string)
     acceptance_required = bool
 
     supported_ip_address_types = list(string)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- fix: A bug fix

## Description

Allows private dns name for VPCES to be optional