### PR TITLE
fix: Authenticate through API only

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -152,11 +152,6 @@ module "eks" {
   managed_node_grp_default            = var.managed_node_grp_default
   managed_node_grps                   = local.managed_node_groups
 
-  create_aws_auth_configmap           = var.create_aws_auth_configmap
-  manage_aws_auth_configmap           = var.manage_aws_auth_configmap
-  aws_auth_users                      = var.aws_auth_users
-  aws_auth_accounts                   = var.aws_auth_accounts
-  aws_auth_roles                      = var.aws_auth_roles
   tags                                = var.tags
   backend_app_port                    = var.backend_app_port
   rds_port                            = var.rds_port

--- a/modules/eks/main.tf
+++ b/modules/eks/main.tf
@@ -47,7 +47,7 @@ module "eks" {
   # https://github.com/terraform-aws-modules/terraform-aws-eks/tree/master/docs
 
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 19.21.0"
+  version = "~> 20.13.1"
   # version = var.eks_module_version
 
   cluster_name    = var.deployment_name
@@ -83,6 +83,7 @@ module "eks" {
   vpc_id                   = var.k8s_vpc
   subnet_ids               = var.k8s_subnets
   control_plane_subnet_ids = var.k8s_control_subnets
+  authentication_mode      = "API"
 
   # Self Managed Node Group(s)
   self_managed_node_group_defaults = var.self_managed_node_grp_default
@@ -96,20 +97,22 @@ module "eks" {
 
   eks_managed_node_groups = var.managed_node_grps
 
-  # aws-auth configmap
-  create_aws_auth_configmap = var.create_aws_auth_configmap
-  manage_aws_auth_configmap = var.manage_aws_auth_configmap
-
-  aws_auth_roles = concat([
-    {
-      rolearn  = aws_iam_role.eks_cluster_role.arn
-      username = "eks_cluster_role"
-      groups   = ["system:masters"]
-    },
-  ], var.aws_auth_roles)
-
-  aws_auth_users    = var.aws_auth_users
-  aws_auth_accounts = var.aws_auth_accounts
+#  access_entries = {
+#    allow_support_access = {
+#      kubernetes_groups = []
+#      principal_arn     = resource.aws_iam_role.eks_support_role.arn  (# from cloud-infra)
+#
+#      policy_associations = {
+#        single = {
+#          policy_arn   = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
+#          access_scope = {
+#            namespaces = []
+#            type       = "cluster"
+#          }
+#        }
+#      }
+#    }
+#  }
 
   tags = var.tags
 }

--- a/modules/eks/variables.tf
+++ b/modules/eks/variables.tf
@@ -73,31 +73,6 @@ variable "managed_node_grps" {
   type = any
 }
 
-variable "create_aws_auth_configmap" {
-  type    = bool
-  default = false
-}
-
-variable "manage_aws_auth_configmap" {
-  type    = bool
-  default = false
-}
-
-variable "aws_auth_users" {
-  type    = list(any)
-  default = []
-}
-
-variable "aws_auth_accounts" {
-  type    = list(any)
-  default = []
-}
-
-variable "aws_auth_roles" {
-  type    = list(any)
-  default = []
-}
-
 variable "tags" {
   type    = any
   default = {}

--- a/variables.tf
+++ b/variables.tf
@@ -692,36 +692,6 @@ variable "default_node_disk_size" {
   description = "Disk size for a node in GB"
 }
 
-variable "create_aws_auth_configmap" {
-  type    = bool
-  default = false
-  description = "Whether to create the AWS authentication configmap"
-}
-
-variable "manage_aws_auth_configmap" {
-  type    = bool
-  default = false
-  description = "Determines whether to manage the aws-auth configmap"
-}
-
-variable "aws_auth_users" {
-  type    = list(any)
-  default = []
-  description = "List of user maps to add to the aws-auth configmap"
-}
-
-variable "aws_auth_accounts" {
-  type    = list(any)
-  default = []
-  description = "List of account maps to add to the aws-auth configmap"
-}
-
-variable "aws_auth_roles" {
-  type    = list(any)
-  default = []
-  description = "List of role maps to add to the aws-auth configmap"
-}
-
 variable "tags" {
   type    = any
   default = {}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- fix: A bug fix

## Description

Upgrades EKS deployment to only authentication through AWS EKS API method, not the deprecrated aws_auth configmap.