### PR TITLE
fix: Restrict IP access to control plane

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -155,6 +155,7 @@ module "eks" {
   tags                                = var.tags
   backend_app_port                    = var.backend_app_port
   rds_port                            = var.rds_port
+  k8s_public_access_cidrs             = var.k8s_public_access_cidrs
 }
 
 module "database" {

--- a/modules/eks/main.tf
+++ b/modules/eks/main.tf
@@ -54,6 +54,7 @@ module "eks" {
   cluster_version = var.k8s_cluster_version
 
   cluster_endpoint_public_access = true
+  cluster_endpoint_public_access_cidrs = var.k8s_public_access_cidrs
 
   enable_irsa = true
 

--- a/modules/eks/variables.tf
+++ b/modules/eks/variables.tf
@@ -88,3 +88,8 @@ variable "rds_port" {
   default     = 5432
   description = "RDS port"
 }
+
+variable "k8s_public_access_cidrs" {
+  type        = list(string)
+  description = "List of CIDRs that are allowed to connect to the EKS control plane"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -697,3 +697,8 @@ variable "tags" {
   default = {}
   description = "Tags to apply to the general module"
 }
+
+variable "k8s_public_access_cidrs" {
+  type        = list(string)
+  description = "List of CIDRs that are allowed to connect to the EKS control plane"
+}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- fix

## Description

This change makes it possible to restrict access to the control plane through IP CIDR whitelisting