### PR TITLE
fix: Set correct name for bucket

### DIFF
--- a/modules/clickhouse_backup/outputs.tf
+++ b/modules/clickhouse_backup/outputs.tf
@@ -1,5 +1,5 @@
 output "clickhouse_s3_bucket" {
-  value = "${var.deployment_name}-${var.clickhouse_s3_bucket}"
+  value =  resource.aws_s3_bucket.clickhouse_backup.id
 }
 
 output "clickhouse_s3_region" {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- fix: A bug fix

## Description

The output name of the S3 bucket is correct for many deployments ,but some use overrides and the output name is not correct there. 