### PR TITLE
fix: VPC Peering routes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -335,5 +335,8 @@ module "vpc_peering" {
   peer_vpc_additional_whitelisted_ingress_cidrs = var.peer_vpc_additional_whitelisted_ingress_cidrs
   ingress_enable_http_sg                        = var.ingress_enable_http_sg
 
-  lb_security_group_id = module.security.lb_security_group_id
+  lb_security_group_id       = module.security.lb_security_group_id
+  vpc_main_route_table_id    = module.networking.vpc_main_route_table_id
+  vpc_private_route_table_id = module.networking.vpc_private_route_table_id
+  vpc_public_route_table_id  = module.networking.vpc_public_route_table_id
 }

--- a/modules/networking/main.tf
+++ b/modules/networking/main.tf
@@ -19,6 +19,9 @@ locals {
     one(module.vpc[*].private_subnets),
     one(data.aws_subnets.private[*].ids)
   )
+  vpc_main_route_table_id = data.aws_vpc.ensured_vpc.main_route_table_id
+  vpc_private_route_table_id = one(data.aws_route_tables.ensured_private_subnet_route_table.ids)
+  vpc_public_route_table_id = one(data.aws_route_tables.ensured_public_subnet_route_table.ids)
 }
 
 #  ┏┓╻┏━╸╻ ╻   ╻ ╻┏━┓┏━╸
@@ -137,6 +140,24 @@ data "aws_subnet" "this" {
 
 data "aws_vpc" "ensured_vpc" {
   id = local.vpc_id
+}
+
+data "aws_route_tables" "ensured_private_subnet_route_table" {
+  vpc_id = local.vpc_id
+
+  filter {
+    name = "tag:Name"
+    values = ["${var.deployment_name}-private"]
+  }
+}
+
+data "aws_route_tables" "ensured_public_subnet_route_table" {
+  vpc_id = local.vpc_id
+
+  filter {
+    name = "tag:Name"
+    values = ["${var.deployment_name}-public"]
+  }
 }
 
 #  ╻ ╻┏━┓┏━╸   ┏━╸╻  ┏━┓╻ ╻   ╻  ┏━┓┏━╸┏━┓

--- a/modules/networking/outputs.tf
+++ b/modules/networking/outputs.tf
@@ -17,3 +17,15 @@ output "vpc_cidr" {
 output "azs" {
   value = local.azs
 }
+
+output "vpc_main_route_table_id" {
+  value = local.vpc_main_route_table_id
+}
+
+output "vpc_private_route_table_id" {
+  value = local.vpc_private_route_table_id
+}
+
+output "vpc_public_route_table_id" {
+  value = local.vpc_public_route_table_id
+}

--- a/modules/vpc_peering/main.tf
+++ b/modules/vpc_peering/main.tf
@@ -13,16 +13,20 @@ resource "aws_vpc_peering_connection" "private_access" {
   }
 }
 
+resource "aws_route" "main_peering_route" {
+  route_table_id            = var.vpc_main_route_table_id
+  destination_cidr_block    = var.peer_vpc_cidr_block
+  vpc_peering_connection_id = aws_vpc_peering_connection.private_access.id
+}
 
-resource "aws_route_table" "private_access" {
-  vpc_id = var.vpc_id
+resource "aws_route" "private_peering_route" {
+  route_table_id            = var.vpc_private_route_table_id
+  destination_cidr_block    = var.peer_vpc_cidr_block
+  vpc_peering_connection_id = aws_vpc_peering_connection.private_access.id
+}
 
-  route {
-    cidr_block = var.peer_vpc_cidr_block
-    vpc_peering_connection_id = aws_vpc_peering_connection.private_access.id
-  }
-
-  tags = {
-    Name = "${var.deployment_name}-peer-route"
-  }
+resource "aws_route" "public_peering_route" {
+  route_table_id            = var.vpc_public_route_table_id
+  destination_cidr_block    = var.peer_vpc_cidr_block
+  vpc_peering_connection_id = aws_vpc_peering_connection.private_access.id
 }

--- a/modules/vpc_peering/variables.tf
+++ b/modules/vpc_peering/variables.tf
@@ -48,3 +48,18 @@ variable "vpc_subnets" {
   description = "The subnets of the VPC"
   type        = list(any)
 }
+
+variable "vpc_main_route_table_id" {
+  description = "The main route table ID of the VPC"
+  type        = string
+}
+
+variable "vpc_private_route_table_id" {
+  description = "The private route table ID of the VPC"
+  type        = string
+}
+
+variable "vpc_public_route_table_id" {
+  description = "The public route table ID of the VPC"
+  type        = string
+}


### PR DESCRIPTION
## Description
Instead of creating a new route table. Add the routes to existing route tables. Routes were missing to the subnet associated route tables.