### PR TITLE
fix: Set default monitor lambda to false

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -772,7 +772,7 @@ variable "github_cidrs" {
 variable "monitor_lambda_datadog" {
   description = "Whether to monitor the Lambda with Datadog"
   type        = bool
-  default     = true
+  default     = false
 }
 
 variable "datadog_api_key" {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- fix: A bug fix

## Description

Default for monitoring lambda should be false.