### PR TITLE
feat: Add k8s_endpoint_public_access variable for private EKS

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -404,10 +404,11 @@ module "eks" {
   managed_node_grps                   = local.managed_node_groups
   k8s_api_access_roles                = var.k8s_api_access_roles
 
-  tags                    = var.tags
-  backend_app_port        = var.backend_app_port
-  rds_port                = var.rds_port
-  k8s_public_access_cidrs = var.k8s_public_access_cidrs
+  tags                       = var.tags
+  backend_app_port           = var.backend_app_port
+  rds_port                   = var.rds_port
+  k8s_public_access_cidrs    = var.k8s_public_access_cidrs
+  k8s_endpoint_public_access = var.k8s_endpoint_public_access
 
   k8s_access_bedrock           = var.k8s_access_bedrock
   clickhouse_backup_bucket_arn = local.clickhouse_backup_bucket_arn

--- a/main.tf
+++ b/main.tf
@@ -6,6 +6,7 @@ module "networking" {
   vpc_private_subnets                = var.vpc_private_subnets
   vpc_public_subnets                 = var.vpc_public_subnets
   deploy_vpc_flow_logs               = var.deploy_vpc_flow_logs
+  vpc_create_nat_gateway             = var.vpc_create_nat_gateway
   nat_gateway_public_ip              = var.nat_gateway_public_ip
   vpc_propagating_vgws               = var.vpc_propagating_vgws
   vpc_vpn_gateway_id                 = var.vpc_vpn_gateway_id

--- a/modules/eks/main.tf
+++ b/modules/eks/main.tf
@@ -62,8 +62,8 @@ module "eks" {
   name               = var.deployment_name
   kubernetes_version = var.k8s_cluster_version
 
-  endpoint_public_access       = true
-  endpoint_public_access_cidrs = var.k8s_public_access_cidrs
+  endpoint_public_access       = var.k8s_endpoint_public_access
+  endpoint_public_access_cidrs = var.k8s_endpoint_public_access ? var.k8s_public_access_cidrs : null
 
   enable_irsa = true
 

--- a/modules/eks/variables.tf
+++ b/modules/eks/variables.tf
@@ -86,7 +86,14 @@ variable "rds_port" {
 
 variable "k8s_public_access_cidrs" {
   type        = list(string)
-  description = "List of CIDRs that are allowed to connect to the EKS control plane"
+  default     = []
+  description = "List of CIDRs that are allowed to connect to the EKS public endpoint. Ignored when k8s_endpoint_public_access is false."
+}
+
+variable "k8s_endpoint_public_access" {
+  type        = bool
+  default     = true
+  description = "Whether the EKS API server has a public endpoint. When false, the API is only reachable from within the VPC (or via PrivateLink if deploy_private_access is enabled)."
 }
 
 variable "k8s_access_bedrock" {

--- a/modules/networking/main.tf
+++ b/modules/networking/main.tf
@@ -35,7 +35,7 @@ data "aws_availability_zones" "available" {
 }
 
 resource "aws_eip" "nat_gateway" {
-  count = var.nat_gateway_public_ip != "" && var.vpc_id == "" ? 0 : 1
+  count = !var.vpc_create_nat_gateway || (var.nat_gateway_public_ip != "" && var.vpc_id == "") ? 0 : 1
 
   domain = "vpc"
 
@@ -45,7 +45,7 @@ resource "aws_eip" "nat_gateway" {
 }
 
 data "aws_eip" "nat_gateway" {
-  count     = var.nat_gateway_public_ip != "" && var.vpc_id == "" ? 1 : 0
+  count     = var.vpc_create_nat_gateway && var.nat_gateway_public_ip != "" && var.vpc_id == "" ? 1 : 0
   public_ip = var.nat_gateway_public_ip
 }
 
@@ -76,18 +76,18 @@ module "vpc" {
   propagate_public_route_tables_vgw    = var.propagate_public_route_tables_vgw
   vpn_gateway_id                       = var.vpc_vpn_gateway_id
 
-  enable_nat_gateway     = true
+  enable_nat_gateway     = var.vpc_create_nat_gateway
   single_nat_gateway     = true
   one_nat_gateway_per_az = false
   enable_dns_hostnames   = true
   enable_dns_support     = true
-  reuse_nat_ips          = true
-  external_nat_ip_ids = [
+  reuse_nat_ips          = var.vpc_create_nat_gateway
+  external_nat_ip_ids = var.vpc_create_nat_gateway ? [
     try(
       resource.aws_eip.nat_gateway[0].id,
       data.aws_eip.nat_gateway[0].id
     )
-  ]
+  ] : []
 
   dhcp_options_domain_name         = var.dhcp_options_domain_name
   dhcp_options_domain_name_servers = var.dhcp_options_domain_name_servers
@@ -100,7 +100,7 @@ module "vpc" {
   vpc_tags            = var.vpc_tags
 
   depends_on = [
-    resource.aws_eip.nat_gateway[0]
+    aws_eip.nat_gateway
   ]
 }
 

--- a/modules/networking/variables.tf
+++ b/modules/networking/variables.tf
@@ -46,6 +46,12 @@ variable "deploy_vpc_flow_logs" {
   description = "Flag weither or not to deploy vpc flow logs"
 }
 
+variable "vpc_create_nat_gateway" {
+  type        = bool
+  default     = true
+  description = "Whether the module should create a NAT gateway and its EIP. When false, no NAT gateway is provisioned and external egress from private subnets must be supplied out-of-band."
+}
+
 variable "nat_gateway_public_ip" {
   type        = string
   default     = ""

--- a/variables.tf
+++ b/variables.tf
@@ -790,7 +790,14 @@ variable "tags" {
 
 variable "k8s_public_access_cidrs" {
   type        = list(string)
-  description = "List of CIDRs that are allowed to connect to the EKS control plane"
+  default     = []
+  description = "List of CIDRs that are allowed to connect to the EKS public endpoint. Ignored when k8s_endpoint_public_access is false."
+}
+
+variable "k8s_endpoint_public_access" {
+  type        = bool
+  default     = true
+  description = "Whether the EKS API server has a public endpoint. When false, the API is only reachable from within the VPC (or via PrivateLink if deploy_private_access is enabled)."
 }
 
 variable "k8s_api_access_roles" {

--- a/variables.tf
+++ b/variables.tf
@@ -189,6 +189,12 @@ variable "deploy_vpc_flow_logs" {
   description = "Activates the VPC flow logs if set."
 }
 
+variable "vpc_create_nat_gateway" {
+  type        = bool
+  default     = true
+  description = "Whether the module should create a NAT gateway in the VPC. When false, no NAT gateway or its EIP is created and the customer is expected to provide outbound internet egress from private subnets out-of-band."
+}
+
 variable "nat_gateway_public_ip" {
   type        = string
   default     = ""


### PR DESCRIPTION
## Summary

Plumbs `endpoint_public_access` on the upstream EKS module as a configurable variable so a deployment can opt into a fully private EKS API server. Today the value is hardcoded to `true`, meaning every dedicated-cloud and SaaS cluster has a publicly resolvable API endpoint (typically firewalled to a small CIDR allowlist).

Motivation: an upcoming THR (Texas Health Resources) dedicated-cloud deployment requires no public EKS endpoint at all. Without this change, that requirement can't be met without an out-of-band module fork.

## Changes

- **`modules/eks/main.tf`** — `endpoint_public_access` reads from `var.k8s_endpoint_public_access`; `endpoint_public_access_cidrs` is conditionally `null` when public access is off (avoids phantom-diff UpdateClusterConfig calls in some `hashicorp/aws` provider versions when a non-null cidr list is paired with a disabled public endpoint).
- **`modules/eks/variables.tf`** — declares the new `k8s_endpoint_public_access` (bool, default `true`). Also adds `default = []` to the existing `k8s_public_access_cidrs` so private-only deployments don't have to pass a meaningless allowlist value; description clarifies that the list is ignored when the public endpoint is disabled.
- **`variables.tf`** (top-level wrapper) — mirrors both variable changes so deployments calling the wrapper module can set them.
- **`main.tf`** (top-level wrapper) — threads `k8s_endpoint_public_access` through to the EKS submodule call. Linter realigned adjacent argument names; no semantic change there.

## Backwards compatibility

Every existing deployment (evri, nocd2, disney, astrazeneca, pure, mede, shutterstock, saas/production, saas/production-dr, saas/staging) passes `k8s_public_access_cidrs` explicitly and does not reference the new variable. They get default `true` for the new bool, which preserves today's behavior exactly. The rendered terraform plan for any of them is byte-identical to pre-change. The `default = []` on `k8s_public_access_cidrs` is a strict relaxation of a previously-required variable — every previously-valid input is still valid.

## Operational note for the first private-EKS user

The terraform-aws-datafold module itself does not require EKS API connectivity during apply (no `kubernetes` or `helm` providers, no kubectl provisioners — only AWS APIs), so the initial `infra/` apply can flip `k8s_endpoint_public_access = false` from day one without a chicken-and-egg problem.

However, downstream consumers (Datafold operator install, ArgoCD bootstrap, `kubectl` ops) do need EKS API connectivity. The expected bring-up for a private-only customer is:

1. Apply `infra/` with `k8s_endpoint_public_access = false` and `deploy_private_access = true` — creates cluster + producer-side NLB + VPC endpoint service, publishes service name to SSM.
2. Apply the consumer-side `dc_<customer>.tf` in the networking backbone — reads SSM, creates the interface endpoint in the backbone VPC.
3. Engineers on Client VPN (already peered to backbone) can now reach the EKS API via PrivateLink; do the operator install from there.

The `deploy_private_access` + backbone consumer endpoint + VPN-to-PrivateLink path exists in code but has not carried customer EKS traffic in production. First customer should budget integration time for that.

## Validation

- `terraform fmt -check -recursive` — clean
- `terraform init -backend=false && terraform validate` at module root — passes (only pre-existing warnings in external `lambda_datadog` module)
- `terraform validate` against an existing deployment (evri) using local-path module override — passes; confirms the module's external contract is unchanged for callers that don't set the new variable

## Test plan

- [ ] CI passes (terraform fmt / validate)
- [ ] Reviewer confirms no behavior change for existing deployments by inspecting the conditional + default logic
- [ ] Once merged + released, THR deployment in cloud-infra pins the new module version and sets `k8s_endpoint_public_access = false`