### PR TITLE
feat: Generate and wire status check token

### DIFF
--- a/examples/deployment/infra/config.tf
+++ b/examples/deployment/infra/config.tf
@@ -1,3 +1,15 @@
+# Generate a random status check token by default. It is used by the server
+# /livez and /readyz probes. Operators can override it by setting the
+# status_check_token variable explicitly.
+resource "random_password" "status_check_token" {
+  length  = 32
+  special = false
+}
+
+locals {
+  status_check_token = coalesce(var.status_check_token, random_password.status_check_token.result)
+}
+
 # Output the infrastructure configuration to console
 output "infra_config" {
   description = "Infrastructure configuration for Datafold deployment"
@@ -32,6 +44,7 @@ output "infra_config" {
       redis_data_volume_id           = module.aws[0].redis_data_volume_id,
       server_name                    = module.aws[0].domain_name,
       vpc_cidr                       = module.aws[0].vpc_cidr,
+      status_check_token             = local.status_check_token,
 
       # service accounts vars
       dfshell_role_arn                        = module.aws[0].dfshell_role_arn,

--- a/examples/deployment/infra/variables.tf
+++ b/examples/deployment/infra/variables.tf
@@ -6,6 +6,6 @@ variable "backend_app_port" {
 
 variable "status_check_token" {
   type        = string
-  default     = "token"
-  description = "The status check token to apply"
+  default     = null
+  description = "The status check token used by the server /livez and /readyz probes. When left unset (null), a random token is generated automatically."
 }

--- a/examples/deployment/infra/versions.tf
+++ b/examples/deployment/infra/versions.tf
@@ -4,5 +4,9 @@ terraform {
       source  = "carlpett/sops"
       version = "~> 0.5"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
   }
 }

--- a/examples/deployment/templates/infra_settings.tpl
+++ b/examples/deployment/templates/infra_settings.tpl
@@ -32,6 +32,7 @@ global:
     server: ${postgres_server}
   serverName: ${server_name}
   vpcCidr: ${vpc_cidr}
+  statusCheckToken: "${status_check_token}"
 
 nginx:
   service:


### PR DESCRIPTION
## What

Provision a per-deployment status-check token and wire it into the rendered Helm values as `global.statusCheckToken`, so the server's `/livez` and `/readyz` probes can validate it.

## Changes

- Add a `random_password` resource (alphanumeric, no special chars — YAML/header-safe) generated **by default**.
- `local`/`output` resolves it via `coalesce(var.status_check_token, <random>)` — operators can pin a value via the `status_check_token` variable.
- Declare the `hashicorp/random` provider.
- Render `statusCheckToken: "${status_check_token}"` into the `global:` block of `infra_settings.tpl` (these are Helm values, consumed by the chart as `global.statusCheckToken`).

## Behavior

A token is generated by default and flows to `global.statusCheckToken`; overridable via the `status_check_token` variable. `terraform validate` clean; rendered output confirmed.
---
## Related — `statusCheckToken` rollout (Option A: typed field)
One change set; fail-open / self-consistent, so pieces merge & deploy in any order:
- **datafold/datafold-operator#123** — typed `Spec.Global.StatusCheckToken` field (emits to Helm `global`) — merged (operator `1.4.0`)
- **datafold/helm-charts#357** — server `STATUS_CHECK_TOKEN` env + CRD schema (combined); re-vendor → operator `1.4.1`
- **datafold/datafold#13136** — server validates the `X-Status-Token` probe header (fail-open when unset)
- **terraform-aws/azure/google-datafold #90 / #28 / #44** — generate a per-cluster token (customer self-hosted)
- **datafold/cloud-infra#1330** — set the token on Datafold-owned cluster seeds (typed `spec.global`)