### PR TITLE
fix: Handle base64-encoded and non-ASCII GitHub webhook payloads

### DIFF
--- a/modules/github_reverse_proxy/lambda_function.py
+++ b/modules/github_reverse_proxy/lambda_function.py
@@ -1,3 +1,4 @@
+import base64
 import json
 import logging
 import os
@@ -34,6 +35,16 @@ def lambda_handler(event, context):
             'statusCode': 400,
             'body': json.dumps('Bad Request: No payload found')
         }
+    if event.get('isBase64Encoded', False):
+        # API Gateway base64-encodes the body when it classifies the
+        # payload as binary; decode back to the original bytes so the
+        # downstream HMAC signature check sees what GitHub signed.
+        body = base64.b64decode(body)
+    elif isinstance(body, str):
+        # Forward bytes, not str: urllib3 1.x (bundled in the Datadog
+        # Lambda layer) falls back to http.client latin-1 encoding for
+        # str bodies and crashes on non-ASCII characters.
+        body = body.encode('utf-8')
     incoming_headers = event.get('headers', {})
 
     logger.info("Starting to forward the payload")

--- a/modules/github_reverse_proxy/test_lambda_function.py
+++ b/modules/github_reverse_proxy/test_lambda_function.py
@@ -1,0 +1,115 @@
+"""Tests for lambda_function.py — run with `python -m unittest`.
+
+Stdlib-only (unittest + http.server): spins up a local HTTP server that
+captures the forwarded request, then invokes lambda_handler the way API
+Gateway does. Verifies the body GitHub signed is forwarded byte-identical
+so the downstream X-Hub-Signature-256 HMAC check passes, for both the
+plain-text and the isBase64Encoded event shapes.
+
+Regression context: non-ASCII characters (em-dash, smart quotes, emoji)
+in PR titles/descriptions crashed the handler under urllib3 1.x (the
+Datadog Lambda layer ships 1.26.x), surfacing as API Gateway 502s on
+single-tenant deployments. To exercise that exact failure mode, run this
+suite under urllib3 1.26.x as well as 2.x.
+"""
+import base64
+import hashlib
+import hmac
+import http.server
+import json
+import os
+import sys
+import threading
+import unittest
+
+WEBHOOK_SECRET = b"test-webhook-secret"
+
+_captured = {}
+
+
+class _CapturingHandler(http.server.BaseHTTPRequestHandler):
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", 0))
+        _captured["body"] = self.rfile.read(length)
+        _captured["headers"] = dict(self.headers)
+        self.send_response(200)
+        self.send_header("Content-Length", "2")
+        self.end_headers()
+        self.wfile.write(b"ok")
+
+    def log_message(self, *args):
+        pass
+
+
+_server = http.server.HTTPServer(("127.0.0.1", 0), _CapturingHandler)
+threading.Thread(target=_server.serve_forever, daemon=True).start()
+
+# lambda_handler reads PRIVATE_SYSTEM_ENDPOINT via os.getenv at call time,
+# but set it before import to mirror the Lambda environment.
+os.environ["PRIVATE_SYSTEM_ENDPOINT"] = (
+    f"http://127.0.0.1:{_server.server_address[1]}/integrations/github/v1/app_hook"
+)
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import lambda_function  # noqa: E402
+
+
+def _github_payload():
+    """A webhook payload with non-ASCII characters typical of AI-written PRs."""
+    payload = {
+        "action": "opened",
+        "pull_request": {
+            "title": "Fix data sync — handle “smart quotes” and emoji \U0001f680",
+            "body": "AI-generated description — it’s typical now",
+        },
+    }
+    return json.dumps(payload, ensure_ascii=False).encode("utf-8")
+
+
+def _sign(body_bytes):
+    return "sha256=" + hmac.new(WEBHOOK_SECRET, body_bytes, hashlib.sha256).hexdigest()
+
+
+class LambdaHandlerTest(unittest.TestCase):
+    def setUp(self):
+        _captured.clear()
+        self.payload_bytes = _github_payload()
+        self.headers = {
+            "Content-Type": "application/json",
+            "Content-Length": str(len(self.payload_bytes)),
+            "X-Hub-Signature-256": _sign(self.payload_bytes),
+            "X-GitHub-Event": "pull_request",
+        }
+
+    def _assert_forwarded_intact(self, result):
+        self.assertEqual(result["statusCode"], 200)
+        received = _captured["body"]
+        self.assertEqual(received, self.payload_bytes)
+        self.assertTrue(
+            hmac.compare_digest(_sign(received), self.headers["X-Hub-Signature-256"])
+        )
+
+    def test_text_event_with_non_ascii_body(self):
+        event = {
+            "body": self.payload_bytes.decode("utf-8"),
+            "isBase64Encoded": False,
+            "headers": self.headers,
+        }
+        self._assert_forwarded_intact(lambda_function.lambda_handler(event, None))
+
+    def test_base64_encoded_event(self):
+        event = {
+            "body": base64.b64encode(self.payload_bytes).decode("ascii"),
+            "isBase64Encoded": True,
+            "headers": self.headers,
+        }
+        self._assert_forwarded_intact(lambda_function.lambda_handler(event, None))
+
+    def test_empty_body_returns_400(self):
+        event = {"body": "", "isBase64Encoded": False, "headers": {}}
+        result = lambda_function.lambda_handler(event, None)
+        self.assertEqual(result["statusCode"], 400)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

GitHub webhooks fail with a **502 `InternalServerErrorException`** on single-tenant
(reverse-proxy) deployments whenever a PR title or description contains non-ASCII
characters — em-dash, smart quotes, emoji (increasingly common in AI-written PRs).
Only single-tenant deployments are affected, because only they route webhooks through
the API Gateway → Lambda reverse proxy in `modules/github_reverse_proxy`.

## Root cause

`modules/github_reverse_proxy/lambda_function.py` reads `event['body']` and forwards it
as a Python `str` via `urllib3.PoolManager().request(...)`, ignoring
`event['isBase64Encoded']`. Two failure modes:

1. **urllib3 1.x latin-1 crash (the actual 502).** The Datadog Python Lambda layer ships
   urllib3 1.26.x, which shadows the runtime's 2.x. urllib3 1.x passes a `str` body through
   to `http.client`, which encodes it as **latin-1** and raises `UnicodeEncodeError` on any
   non-latin-1 character → unhandled Lambda exception → API Gateway 502. (Under urllib3 2.x
   a `str` body is UTF-8 encoded, so a naive local test doesn't show the crash — the bug is
   layer-dependent.)
2. **`isBase64Encoded` pass-through breaks HMAC.** When API Gateway classifies the payload
   as binary and delivers a base64 body, the handler forwards the base64 *string*. The
   downstream `X-Hub-Signature-256` HMAC check is computed over the received bytes →
   signature mismatch → webhook rejected. This breaks under both urllib3 versions.

## Fix

Always forward the body as **bytes**: base64-decode when `isBase64Encoded` is set,
otherwise UTF-8-encode the `str`. No change to logging, error handling, or responses;
the body content is never logged.

## Tests

Added stdlib-only `modules/github_reverse_proxy/test_lambda_function.py` (unittest + a local
`http.server`, no new dependencies). It captures the forwarded bytes and verifies the body is
forwarded byte-identical with a valid HMAC. Covers: a non-ASCII text event, an
`isBase64Encoded` event, and an empty body (still returns 400).

```
$ python -m unittest discover modules/github_reverse_proxy
Ran 3 tests ... OK
```

Verified red→green under both urllib3 1.26.20 (reproduces the latin-1 502 crash and the
base64 HMAC mismatch before the fix) and urllib3 2.7.0. This repo's CI only validates
terraform and the PR title, so the suite runs locally / on demand.

## Notes for reviewers

- **`lambda_function.zip` is intentionally not touched** — terraform's `data "archive_file"`
  regenerates it from `lambda_function.py` at plan/apply time, so the committed zip is a
  stale artifact and hand-zipping it would not match terraform's output.
- **Optional follow-up (not in this PR):** adding `binary_media_types` to the API Gateway
  config would make body delivery consistent. The lambda now handles both text and base64
  events, so that infra change is unnecessary risk here.
- **Deployment note:** semantic-release will cut a new patch module version from this `fix:`
  commit; single-tenant deployments must bump the module version to pick it up.
