### PR TITLE
ci: Release on lambda source changes and allow manual dispatch

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,9 @@ on:
     paths:
       - '*.tf'
       - '**/*.tf'
+      - 'modules/**/*.py'
       - '.github/workflows/release.yaml'
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
I noticed PR #91 (the non-ASCII / base64 GitHub webhook fix) merged to `main` on 2026-06-26 but never produced a release — the latest tag is still `v1.16.0` (2026-06-15).

## Root cause

The release workflow only triggers on `*.tf` changes:

```yaml
on:
  push:
    branches: [main]
    paths:
      - "*.tf"
      - "**/*.tf"
      - ".github/workflows/release.yaml"
```

#91 changed only `modules/github_reverse_proxy/lambda_function.py` (+ its test) — no `.tf` files — so semantic-release never ran and the `fix:` commit is stuck unreleased. This blocks shipping the webhook fix to single-tenant reverse-proxy deployments (Pure, etc.).

## Change

- Add `modules/**/*.py` to the push path filter so Lambda-source-only fixes release automatically.
- Add `workflow_dispatch` so a release can also be triggered manually from the Actions tab.

## Effect

Because `release.yaml` is itself in the path filter, **merging this PR triggers a release run**, which picks up the pending `fix:` commit from #91 and publishes **v1.16.1** (tag + GitHub release + changelog).

After release, Pure’s `cloud-infra` module pin will be bumped to `~> 1.16.1` and applied to deploy the Lambda fix.